### PR TITLE
remove useless use

### DIFF
--- a/app.php
+++ b/app.php
@@ -1,7 +1,6 @@
 <?php
 
 use Symfony\Component\Console\Output\OutputInterface;
-use Exception;
 
 $app = new Silly\Application();
 $app->command('run [--socket=] [--path=] [--full] [--format=]', function (OutputInterface $output, $socket, $path, $full, $format) {
@@ -30,7 +29,7 @@ $app->command('run [--socket=] [--path=] [--full] [--format=]', function (Output
             'SCRIPT_FILENAME' => $path,
             'QUERY_STRING' => implode('&', $query),
         ]);
-    } catch (Exception $e) {
+    } catch (\Exception $e) {
         $output->writeln('<error>Tried sending to PHP-FPM but got the following error: ' . $e->getMessage());
 
         return 1;


### PR DESCRIPTION
Fix PHP warnings like this one:
```
PHP Warning:  The use statement with non-compound name 'Exception' has no effect in [...]/vendor/wizaplace/php-fpm-status-cli/app.php on line 4
```